### PR TITLE
Remove forced comma when merging the fields

### DIFF
--- a/prompt_batcher.py
+++ b/prompt_batcher.py
@@ -56,7 +56,7 @@ class SimplePromptBatcher:
             return ([""],)
 
         prompt_list = [
-            f"{prepend}{', ' if prepend else ''}{p}{', ' if append else ''}{append}"
+            f"{prepend}{p}{append}"
             for p in prompt_list
         ]
 


### PR DESCRIPTION
It's nice to have the option of not having a comma. ie: the prompt_list is a bunch of adjectives and "append" has a noun.

It's still possible to add commas manually if wanted ie: `prepend = "something, "` or `append = ", something"`

This gives more flexibility.